### PR TITLE
Permit empty date in Tufte LaTeX handout

### DIFF
--- a/inst/rmarkdown/templates/tufte_handout/resources/tufte-handout.tex
+++ b/inst/rmarkdown/templates/tufte_handout/resources/tufte-handout.tex
@@ -112,6 +112,8 @@ $if(author)$
 $endif$
 $if(date)$
 \date{$date$}
+$else$
+\date{}
 $endif$
 
 $for(header-includes)$


### PR DESCRIPTION
This commit permits an empty or missing date field in the YAML header.
Without this commit, an empty or missing date field results in the
current date.