### PR TITLE
Adding note about global echo = FALSE

### DIFF
--- a/inst/rmarkdown/templates/tufte_html/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/tufte_html/skeleton/skeleton.Rmd
@@ -79,6 +79,8 @@ $$\frac{d}{dx}\left( \int_{a}^{x} f(u)\,du\right)=f(x).$$
 
 For the sake of portability between LaTeX and HTML, you should keep the margin content as simple as possible (syntax-wise) in the `marginefigure` blocks. You may use simple Markdown syntax like `**bold**` and `_italic_` text, but please refrain from using footnotes, citations, or block-level elements (e.g. blockquotes and lists) there.
 
+Note: if you use `echo=FALSE` in your options chunk, you will have to add `echo=TRUE` to the call, for example ```` ```{marginfigure, echo = TRUE} ````
+
 ## Full Width Figures
 
 You can arrange for figures to span across the entire page by using the chunk option `fig.fullwidth = TRUE`.


### PR DESCRIPTION
When reporting to clients, they tend not to care (nor wish) to see the code. This means it's common to set knitr options such that `echo=FALSE`. With this option set, arbitrary marginfigure chunk content is not shown and this fact is not otherwise documented. However, it's easily fixed by add echo=TRUE to the marginfigure chunk option. I do not know if this effects the LaTeX version, as I don't use latex.