### PR TITLE
Add option "margin_references" to tufte_features.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,11 @@
 
 ## NEW FEATURES
 
-- It is possible to select a subset of some features of the default Tufte style (`tufte-css`) via the `tufte_features` argument of `tufte_html()`. For example, you can disable the `et-book` fonts and the background color.
+- It is possible to select a subset of some features of the default Tufte style (`tufte-css`) via the `tufte_features` argument of `tufte_html()`. 
+    - You can disable the `et-book` fonts 
+    - Remove the default light-yellow background color
+    - Use italics for document headers or not
+    - Choose whether references from citations should be placed in the document margins or at the bottom
 
 - A new variant of the Tufte style, `envisioned`, is added to `tufte_html()`. You can use `tufte_html(tufte_variant = 'envisioned')` to enable this style. The major difference with the default Tufte style is: the font family is `Roboto Condensed`, the background color is `#fefefe`, and the text color is `#222` (thanks, @eddelbuettel, #21).
 

--- a/R/html.R
+++ b/R/html.R
@@ -3,7 +3,8 @@
 #' @param tufte_features A character vector of the CSS features to enable:
 #'   \code{fonts} stands for the \code{et-book} fonts in the \code{tufte-css}
 #'   project, \code{background} means the lightyellow background color of the
-#'   page, and \code{italics} means whether to use italics for the headers. You
+#'   page, \code{italics} means whether to use italics for the headers, and
+#'   \code{margin_references} places citations in margin notes. You
 #'   can enable a subset of these features, or just disable all of them by
 #'   \code{NULL}. When this argument is not used and the \code{tufte_variant}
 #'   argument is not \code{default}, no features are enabled.
@@ -16,7 +17,7 @@
 #' @rdname tufte_handout
 #' @export
 tufte_html = function(
-  ..., tufte_features = c('fonts', 'background', 'italics'),
+  ..., tufte_features = c('fonts', 'background', 'italics', 'margin_references'),
   tufte_variant = c('default', 'envisioned')
 ) {
 
@@ -68,7 +69,8 @@ tufte_html = function(
     if (length(footnotes$range)) x = x[-footnotes$range]
 
     # replace citations with margin notes
-    x = margin_references(x)
+    if ('margin_references' %in% tufte_features)
+      x = margin_references(x)
 
     # place figure captions in margin notes
     x[x == '<p class="caption">'] = '<p class="caption marginnote shownote">'

--- a/R/html.R
+++ b/R/html.R
@@ -1,6 +1,6 @@
 #' @details \code{tufte_html()} provides the HTML format based on the Tufte CSS:
 #'   \url{https://edwardtufte.github.io/tufte-css/}.
-#' @param tufte_features A character vector of the CSS features to enable:
+#' @param tufte_features A character vector of the \code{tufte_html()} features to enable:
 #'   \code{fonts} stands for the \code{et-book} fonts in the \code{tufte-css}
 #'   project, \code{background} means the lightyellow background color of the
 #'   page, \code{italics} means whether to use italics for the headers, and

--- a/R/html.R
+++ b/R/html.R
@@ -1,6 +1,6 @@
 #' @details \code{tufte_html()} provides the HTML format based on the Tufte CSS:
 #'   \url{https://edwardtufte.github.io/tufte-css/}.
-#' @param tufte_features A character vector of the \code{tufte_html()} features to enable:
+#' @param tufte_features A character vector of style features to enable:
 #'   \code{fonts} stands for the \code{et-book} fonts in the \code{tufte-css}
 #'   project, \code{background} means the lightyellow background color of the
 #'   page, \code{italics} means whether to use italics for the headers, and

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -46,7 +46,7 @@ sans_serif(text)
 argument in \code{tufte_handout} or the \code{theme} argument in
 \code{tufte_html()}; these arguments have been set internally)}
 
-\item{tufte_features}{A character vector of the \code{tufte_html()} features to enable:
+\item{tufte_features}{A character vector of style features to enable:
 \code{fonts} stands for the \code{et-book} fonts in the \code{tufte-css}
 project, \code{background} means the lightyellow background color of the
 page, \code{italics} means whether to use italics for the headers, and

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -16,8 +16,8 @@ tufte_handout(fig_width = 4, fig_height = 2.5, fig_crop = TRUE, dev = "pdf",
 tufte_book(fig_width = 4, fig_height = 2.5, fig_crop = TRUE, dev = "pdf", 
     highlight = "default", ...)
 
-tufte_html(..., tufte_features = c("fonts", "background", "italics"), 
-    tufte_variant = c("default", "envisioned"))
+tufte_html(..., tufte_features = c("fonts", "background", "italics", 
+    "margin_references"), tufte_variant = c("default", "envisioned"))
 
 newthought(text)
 
@@ -49,7 +49,8 @@ argument in \code{tufte_handout} or the \code{theme} argument in
 \item{tufte_features}{A character vector of the CSS features to enable:
 \code{fonts} stands for the \code{et-book} fonts in the \code{tufte-css}
 project, \code{background} means the lightyellow background color of the
-page, and \code{italics} means whether to use italics for the headers. You
+page, \code{italics} means whether to use italics for the headers, and
+\code{margin_references} places citations in margin notes. You
 can enable a subset of these features, or just disable all of them by
 \code{NULL}. When this argument is not used and the \code{tufte_variant}
 argument is not \code{default}, no features are enabled.}

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -46,7 +46,7 @@ sans_serif(text)
 argument in \code{tufte_handout} or the \code{theme} argument in
 \code{tufte_html()}; these arguments have been set internally)}
 
-\item{tufte_features}{A character vector of the CSS features to enable:
+\item{tufte_features}{A character vector of the \code{tufte_html()} features to enable:
 \code{fonts} stands for the \code{et-book} fonts in the \code{tufte-css}
 project, \code{background} means the lightyellow background color of the
 page, \code{italics} means whether to use italics for the headers, and


### PR DESCRIPTION
Hi,

I need a document with the references at the end of the document instead of in margin notes. So I added a tufte_feature for the citations.

I'll send the contributor agreement shortly even though I don't think that changes this small are even protected by copyright. :)

Ciao
Stefan