### PR TITLE
Adjust regex for moving footnotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tufte
 Type: Package
 Title: Tufte's Styles for R Markdown Documents
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "aut"),
@@ -20,4 +20,4 @@ Imports:
     xfun (>= 0.6),
     knitr (>= 1.22),
     rmarkdown (>= 1.12)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN tufte VERSION 0.6
 
+## BUG FIXES
 
+- Footnotes no longer work with Pandoc >= 2.7 (thanks, @grimbough, #76).
 
 # CHANGES IN tufte VERSION 0.5
 

--- a/R/html.R
+++ b/R/html.R
@@ -182,7 +182,7 @@ parse_footnotes = function(x, fn_label = 'fn') {
   j = min(j[j > i])
   n = length(x)
   r = sprintf(
-    '<li id="%s([0-9]+)"><p>(.+)<a href="#%sref\\1"([^>]*)>.</a></p></li>',
+    '<li id="%s([0-9]+)"><p>(.+)<a href="#%sref\\1"([^>]*)>.{1,2}</a></p></li>',
     fn_label, fn_label
   )
   s = paste(x[i:j], collapse = '\n')


### PR DESCRIPTION
I've encountered an issue where footnotes are not correctly moved to numbered margin notes, they're just dropped.  The problem happens when the pandoc generated HTML file is being modified.

The cause seems to be because the 'left facing arrow with hook' (↩) pandoc inserts into the footnote link now includes some additional hidden bytes, that aren't matched by the regular expression that moves the footnotes.

This patch just expands the regular expression to allow for one or two characters, which seems sufficient to match the new version but should be backwards compatible if this is a quirk of my system.  The following picture shows the missing footnotes and the same document with this patch 

![image](https://user-images.githubusercontent.com/971237/77343736-795aaf00-6d32-11ea-9f70-bc9a1fdb079a.png)

----

Going into a bit more detail:

For me this only occurs on a system running RStudio 1.3.869 and is fine on a separate computer using RStudio 1.2.5033. I suspect the change in pandoc versions (2.7.3 vs 2.3.1) is the culprit but I can't find any release notes detailing this and there are many other difference between the two computers.  All R packages are the same, happy to provide versions if they're useful.

To examine the behaviour the following will produce a minimal example:

```r
## temporary files
tmp_md <- tempfile(fileext = ".md")
tmp_html <- tempfile(fileext = ".html")

## write a really small markdown file
x <- "test^[this is a test]"
xfun::write_utf8(x, con = tmp_md)

## convert to HTML & read back into R
rmarkdown::pandoc_convert(input = tmp_md, to = "html", output = tmp_html)
html <- xfun::read_utf8(tmp_html)
```

On a system where the footnotes are fine I see the following:

```r
> file.size(tmp_html)
[1] 212
> substr(html[5], 71, 71)
[1] "↩"
> substr(html[5], 71, 72)
[1] "↩︎<"
```

On a machine where this is failing those commands do:

```r
> file.size(tmp_html)
[1] 215
> substr(html[5], 71, 71)
[1] "↩"
> substr(html[5], 71, 72)
[1] "↩︎"
```

The three extra bytes seem to be a Unicode ['Variation Selector 15](https://www.fileformat.info/info/unicode/char/fe0e/index.htm)'

```r
> charToRaw(substr(html[5], 72, 72))
[1] ef b8 8e
```

This also affects Bioconductor/BiocStyle#72