### PR TITLE
Correctly move references in margin with Pandoc 2.11 new citeproc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tufte
 Type: Package
 Title: Tufte's Styles for R Markdown Documents
-Version: 0.7.1
+Version: 0.7.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("JJ", "Allaire", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN tufte VERSION 0.8
 
+- References are now moved in the margin correctly with Pandoc 2.11 (#86).
+
 - Add a `runningheader` variable in the template for `tufte_handout()` and `tufte_book()` to have a different running header than the title if provided. (#82)
 
 # CHANGES IN tufte VERSION 0.7

--- a/R/html.R
+++ b/R/html.R
@@ -198,7 +198,7 @@ margin_references = function(x) {
   if (length(i) != 1) return(x)
   # link-citations: no
   if (length(grep('<a href="#ref-[^"]+"[^>]*>([^<]+)</a>', x)) == 0) return(x)
-  r = '^<div id="(ref-[^"]+)">$'
+  r = '^<div id="(ref-[^"]+)"[^>]*>$'
   k = grep(r, x)
   k = k[k > i]
   n = length(k)


### PR DESCRIPTION
This will close #85 

First change is to take into account the new classes added by Pandoc. Ex: 
```html
<div id="ref-xie2015" class="csl-entry">
Xie, Yihui. 2015. <em>Dynamic Documents with <span>R</span> and Knitr</em>. 2nd ed. Boca Raton, Florida: Chapman; Hall/CRC. <a href="http://yihui.name/knitr/">http://yihui.name/knitr/</a>.
</div>
```

Second change is that new citeproc will generate two links, e.g <span class="citation"><a href="#ref-R-rmarkdown" role="doc-biblioref">Allaire et al.</a> (<a href="#ref-R-rmarkdown" role="doc-biblioref">2020</a>)</span>
```html
<span class="citation"><a href="#ref-R-rmarkdown" role="doc-biblioref">Allaire et al.</a> (<a href="#ref-R-rmarkdown" role="doc-biblioref">2020</a>)</span>
```

Previously with Pandoc 2.7, we had only one, e.g <span class="citation">Allaire et al. (<a href="#ref-R-rmarkdown" role="doc-biblioref">2020</a>)</span>
```html
<span class="citation">Allaire et al. (<a href="#ref-R-rmarkdown" role="doc-biblioref">2020</a>)</span>
```

And **tufte** seems to support from a long time now, merging links (https://github.com/rstudio/tufte/commit/d6a57483330a2676232aec2681190ce621a2a296) - it seems to be for <a href="#cite-key">2016</a><a href="#cite-key">a</a>, so year with suffix. 

@yihui, I tried to follow the same logic with regex (and it is a use case for regexec maybe?). 
However, I wonder if we should not have a condition on `rmarkdown::pandoc_available("2.11")` to have a new regex for new citeproc. Two processing for this, depending on the Pandoc version. 
In fact, I am not sure if there won't be more than 2 links sometimes. How do I generate a reference entry with a alphatetic suffix to try with Pandoc 2.11 ? 

Also, with this PR, the linked will be merged and, with Pandoc 2.11+, we will have the toggle logic to apply on the all Name + year (`Allaire et al. (2020)`) and not just the year as before.

With Pandoc 2.11: 
![image](https://user-images.githubusercontent.com/6791940/96013143-38002d00-0e45-11eb-91c0-2b0752aef41b.png)

With Pandoc 2.7.3: 
![image](https://user-images.githubusercontent.com/6791940/96013279-5ebe6380-0e45-11eb-931c-a369501d3dfd.png)

I left this PR as a draft as I am not sure of the fix and this need to be tested with alphabetic suffix
