### PR TITLE
Add CSLReferences environment for Pandoc 2.11 new citeproc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN tufte VERSION 0.9
 
+- Add the missing `CSLReferences` environment in the template required by Pandoc 2.11+ and its new citeproc (#89)
 
 # CHANGES IN tufte VERSION 0.8
 
@@ -9,7 +10,7 @@
 
 # CHANGES IN tufte VERSION 0.7
 
-- Added the `cslreferences` environment the template (thanks, @jonathan-g, #80).
+- Add the `cslreferences` environment in the template (thanks, @jonathan-g, #80).
 
 # CHANGES IN tufte VERSION 0.6
 

--- a/inst/rmarkdown/templates/tufte_handout/resources/tufte-handout.tex
+++ b/inst/rmarkdown/templates/tufte_handout/resources/tufte-handout.tex
@@ -96,10 +96,30 @@ $endif$
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
+% For Pandoc 2.8 to 2.11
 \newenvironment{cslreferences}%
   {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
   \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
   {\par}
+% For pandoc 2.11+ using new --citeproc
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[3] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set entry spacing
+  \ifnum #2 > 0
+  \setlength{\parskip}{#2\baselineskip}
+  \fi
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 
 % pandoc syntax highlighting


### PR DESCRIPTION
Which is required to be in the template. 
We follow the pandoc template: https://github.com/jgm/pandoc-templates/blame/b5f9ac0d0ec74abfaf7bdbc27ee0bee11391d0ee/default.latex#L374