### PR TITLE
correctly parse footnotes with Pandoc 2.15+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN tufte VERSION 0.12
 
+- Fix footnotes as sidenotes issue with Pandoc 2.15 and later (thanks, @MCMaurer, #108).
+
 
 # CHANGES IN tufte VERSION 0.11
 

--- a/R/html.R
+++ b/R/html.R
@@ -176,7 +176,7 @@ tufte_html_dependency = function(features, variant) {
 # we assume one footnote only contains one paragraph here, although it is
 # possible to write multiple paragraphs in a footnote with Pandoc's Markdown
 parse_footnotes = function(x, fn_label = 'fn') {
-  i = which(x == '<div class="footnotes">')
+  i = grep('^<div class="footnotes[^"]*"[^>]*>', x)
   if (length(i) == 0) return(list(items = character(), range = integer()))
   j = which(x == '</div>')
   j = min(j[j > i])

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -21,3 +21,29 @@ skip_if_pandoc <- function(ver = NULL) {
     skip(msg)
   }
 }
+
+local_rmd_file <- function(..., .env = parent.frame()) {
+  path <- withr::local_tempfile(.local_envir = .env, fileext = ".Rmd")
+  xfun::write_utf8(c(...), path)
+  path
+}
+
+local_render <- function(input, ..., .env = parent.frame()) {
+  skip_if_not_pandoc()
+  output_file <- withr::local_tempfile(.local_envir = .env)
+  rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
+}
+
+local_pandoc_convert <- function(text, from = "markdown", ..., .env = parent.frame()) {
+  skip_if_not_pandoc()
+  rmd <- local_rmd_file(text)
+  out <- withr::local_tempfile(.local_envir = .env)
+  rmarkdown::pandoc_convert(rmd, from = from, output = out, ...)
+  xfun::read_utf8(out)
+}
+
+.render_and_read <- function(input, ...) {
+  skip_if_not_pandoc()
+  res <- local_render(input, ...)
+  xfun::read_utf8(res)
+}

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -34,11 +34,12 @@ local_render <- function(input, ..., .env = parent.frame()) {
   rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
 }
 
-local_pandoc_convert <- function(text, from = "markdown", ..., .env = parent.frame()) {
+local_pandoc_convert <- function(text, from = "markdown", options = NULL, ..., .env = parent.frame()) {
   skip_if_not_pandoc()
   rmd <- local_rmd_file(text)
   out <- withr::local_tempfile(.local_envir = .env)
-  rmarkdown::pandoc_convert(rmd, from = from, output = out, ...)
+  rmarkdown::pandoc_convert(rmd, from = from, output = out,
+                            options = c("--wrap", "preserve", options), ...)
   xfun::read_utf8(out)
 }
 

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -44,3 +44,14 @@ test_that("put references in margin when link-citations: yes using csl", {
   expect_refs_margin(moved = TRUE, variant = pandoc_variant, c("--csl", "https://www.zotero.org/styles/apa-6th-edition"))
   expect_refs_margin(moved = TRUE, variant = pandoc_variant, c("--csl", "https://www.zotero.org/styles/chicago-author-date-16th-edition"))
 })
+
+test_that("footnotes are correctly parsed", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  pandoc_html <- local_pandoc_convert("Here is some text^[This should be a sidenote].",
+                                      to = "html4")
+  expect_identical(
+    parse_footnotes(pandoc_html),
+    list(items = "This should be a sidenote", range = 2:7)
+  )
+})


### PR DESCRIPTION
This fixes #108 

Pandoc 2.15 is adding some classes on the div for footnotes we need to support this. 

````r
> pandoc::pandoc_convert(text = "Here is some text^[This should be a sidenote]", to = "html4", version = "2.15")
<p>Here is some text<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a></p>
<div class="footnotes footnotes-end-of-document">
<hr />
<ol>
<li id="fn1"><p>This should be a sidenote<a href="#fnref1" class="footnote-back">â†©ï¸Ž</a></p></li>
</ol>
</div>
> pandoc::pandoc_convert(text = "Here is some text^[This should be a sidenote]", to = "html4", version = "2.14.2")
<p>Here is some text<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a></p>
<div class="footnotes">
<hr />
<ol>
<li id="fn1"><p>This should be a sidenote<a href="#fnref1" class="footnote-back">â†©ï¸Ž</a></p></li>
</ol>
</div>
````

I have added test for this too