### PR TITLE
Fix test snapshot due to Pandoc change

### DIFF
--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -14,7 +14,7 @@ expect_refs_margin <- function(moved = FALSE, options = NULL, ..., variant = NUL
   rmarkdown::pandoc_convert(basename(rmd_temp), "html4", "markdown",
                             output = out, citeproc = TRUE, verbose = FALSE,
                             wd = dirname(rmd_temp),
-                            options = c("--wrap", "none", options), ...)
+                            options = c("--wrap", "preserve", options), ...)
   x <- xfun::read_utf8(out)
   expect_snapshot(margin_references(x), variant = variant)
 }

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -3,7 +3,7 @@ test_that("add marginnote", {
   expect_snapshot(marginnote_html("text", "#"))
 })
 
-expect_refs_margin <- function(moved = FALSE, ..., variant = NULL) {
+expect_refs_margin <- function(moved = FALSE, options = NULL, ..., variant = NULL) {
   rmd <- test_path("resources/margins_references.Rmd")
   out <- withr::local_tempfile(fileext = ".html")
   rmd_temp <- withr::local_tempfile(fileext = ".Rmd")
@@ -12,8 +12,9 @@ expect_refs_margin <- function(moved = FALSE, ..., variant = NULL) {
     rmd_temp
   )
   rmarkdown::pandoc_convert(basename(rmd_temp), "html4", "markdown",
-                                   output = out, citeproc = TRUE, verbose = FALSE,
-                                   wd = dirname(rmd_temp), ...)
+                            output = out, citeproc = TRUE, verbose = FALSE,
+                            wd = dirname(rmd_temp),
+                            options = c("--wrap", "none", options), ...)
   x <- xfun::read_utf8(out)
   expect_snapshot(margin_references(x), variant = variant)
 }

--- a/tufte.Rproj
+++ b/tufte.Rproj
@@ -16,6 +16,7 @@ AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
 
 BuildType: Package
+PackageUseDevtools: Yes
 PackageInstallArgs: -v && Rscript -e "Rd2roxygen::rab(build=F,install=T)"
 PackageBuildArgs: -v && Rscript -e "Rd2roxygen::rab(build=T,install=F)"
 PackageCheckArgs: --as-cran


### PR DESCRIPTION
Panodc 2.17 now wraps HTML by default. We insure it is not as other versions