### PR TITLE
Update email alias for sending CLAs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ We welcome contributions to the **tufte** package. To submit a contribution:
 
 1. [Fork](https://github.com/rstudio/tufte/fork) the repository and make your changes.
 
-2. Ensure that you have signed the [individual](https://www.rstudio.com/wp-content/uploads/2014/06/RStudioIndividualContributorAgreement.pdf) or [corporate](https://www.rstudio.com/wp-content/uploads/2014/06/RStudioCorporateContributorAgreement.pdf) contributor agreement as appropriate. You can send the signed copy to jj@rstudio.com.
+2. Ensure that you have signed the [individual](https://www.rstudio.com/wp-content/uploads/2014/06/RStudioIndividualContributorAgreement.pdf) or [corporate](https://www.rstudio.com/wp-content/uploads/2014/06/RStudioCorporateContributorAgreement.pdf) contributor agreement as appropriate. You can send the signed copy to contribute@rstudio.com.
 
 3. Submit a [pull request](https://help.github.com/articles/using-pull-requests).
 


### PR DESCRIPTION
Updating to email address people should send CLAs to.

More on this at: https://github.com/rstudio/rstudio/issues/10609
