### PR TITLE
use "auto" for fig_crop like in rmarkdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tufte (development version)
 
+- Changed the default value of `fig_crop` from `TRUE` to `"auto"` in `tufte_handout()` and `tufte_book()`, consistent with `rmarkdown::pdf_document()`. This avoids a spurious warning about `pdfcrop` not being found when the crop tools are not installed (thanks, @sandhya9215, 
+#124).
+
 # tufte 0.14.0
 
 # CHANGES IN tufte VERSION 0.14 (development version)

--- a/R/handout.R
+++ b/R/handout.R
@@ -16,7 +16,7 @@
 tufte_handout <- function(
   fig_width = 4,
   fig_height = 2.5,
-  fig_crop = TRUE,
+  fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
   ...
@@ -37,7 +37,7 @@ tufte_handout <- function(
 tufte_book <- function(
   fig_width = 4,
   fig_height = 2.5,
-  fig_crop = TRUE,
+  fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
   ...
@@ -49,7 +49,7 @@ tufte_pdf <- function(
   documentclass = c("tufte-handout", "tufte-book"),
   fig_width = 4,
   fig_height = 2.5,
-  fig_crop = TRUE,
+  fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
   template = template_resources("tufte_handout", "tufte-handout.tex"),

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -13,7 +13,7 @@
 tufte_handout(
   fig_width = 4,
   fig_height = 2.5,
-  fig_crop = TRUE,
+  fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
   ...
@@ -22,7 +22,7 @@ tufte_handout(
 tufte_book(
   fig_width = 4,
   fig_height = 2.5,
-  fig_crop = TRUE,
+  fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
   ...

--- a/tests/testthat/test-handout.R
+++ b/tests/testthat/test-handout.R
@@ -1,0 +1,40 @@
+test_that("tufte_handout() does not warn about crop tools", {
+  expect_no_warning(tufte_handout())
+})
+
+test_that("tufte_book() does not warn about crop tools", {
+  expect_no_warning(tufte_book())
+})
+
+test_that("fig_crop = 'auto' is passed through to pdf_document", {
+  fmt <- tufte_handout()
+  # When crop tools are missing, the knitr options should not include crop hook
+  if (!nzchar(Sys.which("pdfcrop")) || !nzchar(Sys.which("gs"))) {
+    expect_null(fmt$knitr$knit_hooks$crop)
+  }
+})
+
+test_that("tufte_handout renders without pdfcrop warnings", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  rmd <- local_rmd_file(c(
+    "---",
+    "title: test",
+    "output: tufte::tufte_handout",
+    "---",
+    "",
+    "Hello world."
+  ))
+  # Suppress unrelated LaTeX warnings, but fail on any crop-related ones
+  withCallingHandlers(
+    local_render(rmd),
+    warning = function(w) {
+      msg <- conditionMessage(w)
+      if (grepl("pdfcrop|crop_tools|ghostscript", msg)) {
+        fail(paste("Unexpected crop tool warning:", msg))
+      }
+      invokeRestart("muffleWarning")
+    }
+  )
+  succeed()
+})

--- a/tests/testthat/test-handout.R
+++ b/tests/testthat/test-handout.R
@@ -6,12 +6,13 @@ test_that("tufte_book() does not warn about crop tools", {
   expect_no_warning(tufte_book())
 })
 
-test_that("fig_crop = 'auto' is passed through to pdf_document", {
+test_that("fig_crop = 'auto' disables crop hook when tools are missing", {
+  skip_if_not(
+    !nzchar(Sys.which("pdfcrop")) || !nzchar(Sys.which("gs")),
+    "pdfcrop or ghostscript must be missing for this test"
+  )
   fmt <- tufte_handout()
-  # When crop tools are missing, the knitr options should not include crop hook
-  if (!nzchar(Sys.which("pdfcrop")) || !nzchar(Sys.which("gs"))) {
-    expect_null(fmt$knitr$knit_hooks$crop)
-  }
+  expect_null(fmt$knitr$knit_hooks$crop)
 })
 
 test_that("tufte_handout renders without pdfcrop warnings", {


### PR DESCRIPTION
fix #124 

This make tufte default same as rmarkdown one