### PR TITLE
Fixed `fig.margin = TRUE` (and `fig.fullwidth = TRUE`) being ignored

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tufte
 Title: Tufte's Styles for R Markdown Documents
-Version: 0.14.0.9001
+Version: 0.14.0.9002
 Authors@R: c(
     person("Yihui", "Xie", role = "aut", email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Christophe", "Dervieux", role = c("ctb", "cre"), email = "cderv@posit.co", comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,13 @@
 - Changed the default value of `fig_crop` from `TRUE` to `"auto"` in `tufte_handout()` and `tufte_book()`, consistent with `rmarkdown::pdf_document()`. This avoids a spurious warning about `pdfcrop` not being found when the crop tools are not installed (thanks, @sandhya9215, 
 #124).
 
-- Removed obsolete `usenames` option from `xcolor` package loading to suppress warning on TeX Live 2022+ (#127).
+- Fixed `fig.margin = TRUE` (and `fig.fullwidth = TRUE`) being ignored when
+  `fig.align` is set in HTML output. The margin/fullwidth wrapper was silently
+  dropped because the figure hook used an exact string match that missed the
+  extra `style` attribute added by knitr (#54).
+
+- Removed obsolete `usenames` option from `xcolor` package loading to suppress
+  warning on TeX Live 2022+ (#127).
 
 # tufte 0.14.0
 

--- a/R/html.R
+++ b/R/html.R
@@ -179,8 +179,11 @@ tufte_html <- function(
       )
       res <- gsub_fixed("</p>", "<!--</p>-->", res)
       res <- gsub_fixed("</div>", "<!--</div>--></span></p>", res)
-      res <- gsub_fixed(
-        '<div class="figure">',
+      # Use regex to match <div class="figure"> with optional style attribute
+      # (e.g. from fig.align); the style is dropped since margin positioning
+      # is handled by the marginnote CSS class
+      res <- gsub(
+        '<div class="figure"[^>]*>',
         paste0(
           "<p>",
           '<span class="marginnote shownote">',
@@ -189,8 +192,9 @@ tufte_html <- function(
         res
       )
     } else if (fig_fullwd) {
-      res <- gsub_fixed(
-        '<div class="figure">',
+      # Use regex to match optional style attribute from fig.align
+      res <- gsub(
+        '<div class="figure"[^>]*>',
         '<div class="figure fullwidth">',
         res
       )

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -94,7 +94,12 @@ test_that("fig.margin=TRUE works with fig.align set (issue #54)", {
   )
   # The raw <div class="figure" style="text-align: ..."> should NOT appear
   # (it should be commented out inside the marginnote wrapper)
-  raw_div <- grep('<div class="figure" style=', html, fixed = TRUE, value = TRUE)
+  raw_div <- grep(
+    '<div class="figure" style=',
+    html,
+    fixed = TRUE,
+    value = TRUE
+  )
   expect_true(
     all(grepl("<!--", raw_div)),
     info = "fig div with style should be inside HTML comment when fig.margin=TRUE"

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -72,6 +72,56 @@ test_that("put references in margin when link-citations: yes using csl", {
   )
 })
 
+test_that("fig.margin=TRUE works with fig.align set (issue #54)", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  rmd <- local_rmd_file(
+    "---",
+    "title: test",
+    "output: tufte::tufte_html",
+    "---",
+    "",
+    '```{r fig-margin-align, fig.margin=TRUE, fig.align="center", fig.cap="test cap"}',
+    "plot(1)",
+    "```"
+  )
+  html <- .render_and_read(rmd)
+  # The margin figure wrapper must be present
+  margin_lines <- grep("marginnote shownote", html, value = TRUE)
+  expect_true(
+    length(margin_lines) > 0,
+    info = "fig.margin=TRUE with fig.align should still produce marginnote wrapper"
+  )
+  # The raw <div class="figure" style="text-align: ..."> should NOT appear
+  # (it should be commented out inside the marginnote wrapper)
+  raw_div <- grep('<div class="figure" style=', html, fixed = TRUE, value = TRUE)
+  expect_true(
+    all(grepl("<!--", raw_div)),
+    info = "fig div with style should be inside HTML comment when fig.margin=TRUE"
+  )
+})
+
+test_that("fig.fullwidth=TRUE works with fig.align set", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  rmd <- local_rmd_file(
+    "---",
+    "title: test",
+    "output: tufte::tufte_html",
+    "---",
+    "",
+    '```{r fig-full-align, fig.fullwidth=TRUE, fig.align="center", fig.cap="test cap"}',
+    "plot(1)",
+    "```"
+  )
+  html <- .render_and_read(rmd)
+  fullwidth_lines <- grep("figure fullwidth", html, value = TRUE)
+  expect_true(
+    length(fullwidth_lines) > 0,
+    info = "fig.fullwidth=TRUE with fig.align should produce fullwidth class"
+  )
+})
+
 test_that("footnotes are correctly parsed", {
   skip_on_cran()
   skip_if_not_pandoc()


### PR DESCRIPTION
when `fig.align` is set in HTML output. The margin/fullwidth wrapper was silently dropped because the figure hook used an exact string match that missed the extra `style` attribute added by knitr 

closes #54