### PR TITLE
Add margin_fig_pos option for margin figure vertical offset (#62)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tufte
 Title: Tufte's Styles for R Markdown Documents
-Version: 0.14.0.9002
+Version: 0.14.0.9003
 Authors@R: c(
     person("Yihui", "Xie", role = "aut", email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Christophe", "Dervieux", role = c("ctb", "cre"), email = "cderv@posit.co", comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,14 @@
 - Removed obsolete `usenames` option from `xcolor` package loading to suppress
   warning on TeX Live 2022+ (#127).
 
+- Added new `margin_fig_pos` option to `tufte_handout()` and `tufte_book()`
+  for controlling the vertical offset of margin figures globally. This can be
+  set in YAML (e.g. `margin_fig_pos: "0cm"`), via
+  `knitr::opts_chunk$set(margin_fig_pos = "0cm")`, or per-chunk. Per-chunk
+  `fig.pos` still overrides it. This addresses the margin figure alignment
+  issue without the semantic mismatch of setting `fig.pos` globally, which
+  would break regular figures (#62).
+
 # tufte 0.14.0
 
 # CHANGES IN tufte VERSION 0.14 (development version)

--- a/R/handout.R
+++ b/R/handout.R
@@ -6,6 +6,15 @@
 #' `tufte_handout()` provides the PDF format based on the Tufte-LaTeX
 #' class: <https://tufte-latex.github.io/tufte-latex/>.
 #' @inheritParams rmarkdown::pdf_document
+#' @param margin_fig_pos Default vertical offset for margin figures (a LaTeX
+#'   length such as `"0cm"` or `"-5pt"`). When set, this value is used as the
+#'   `fig.pos` for all chunks with `fig.margin = TRUE`, unless the chunk
+#'   specifies its own `fig.pos`. This avoids the problem of setting `fig.pos`
+#'   globally via `knitr::opts_chunk$set()`, which would also affect regular
+#'   figures where `fig.pos` is a placement specifier (e.g. `"htbp"`), not a
+#'   length. Can also be set per-chunk or via `knitr::opts_chunk$set()` as the
+#'   `margin_fig_pos` chunk option. Defaults to `NULL` (use the Tufte-LaTeX
+#'   class default of `-1.2ex`).
 #' @param ... Other arguments to be passed to [rmarkdown::pdf_document()] or
 #'   [rmarkdown::html_document()] (note you cannot use the `template`
 #'   argument in `tufte_handout` or the `theme` argument in
@@ -19,6 +28,7 @@ tufte_handout <- function(
   fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
+  margin_fig_pos = NULL,
   ...
 ) {
   tufte_pdf(
@@ -28,6 +38,7 @@ tufte_handout <- function(
     fig_crop,
     dev,
     highlight,
+    margin_fig_pos = margin_fig_pos,
     ...
   )
 }
@@ -40,9 +51,19 @@ tufte_book <- function(
   fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
+  margin_fig_pos = NULL,
   ...
 ) {
-  tufte_pdf("tufte-book", fig_width, fig_height, fig_crop, dev, highlight, ...)
+  tufte_pdf(
+    "tufte-book",
+    fig_width,
+    fig_height,
+    fig_crop,
+    dev,
+    highlight,
+    margin_fig_pos = margin_fig_pos,
+    ...
+  )
 }
 
 tufte_pdf <- function(
@@ -52,6 +73,7 @@ tufte_pdf <- function(
   fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
+  margin_fig_pos = NULL,
   template = template_resources("tufte_handout", "tufte-handout.tex"),
   ...
 ) {
@@ -128,13 +150,26 @@ tufte_pdf <- function(
 
   # set options
   knitr_options$opts_knit$width <- 45
+  if (!is.null(margin_fig_pos)) {
+    knitr_options$opts_chunk$margin_fig_pos <- margin_fig_pos
+  }
 
   # set hooks for special plot output
   knitr_options$knit_hooks$plot <- function(x, options) {
     # determine figure type
     if (isTRUE(options$fig.margin)) {
       options$fig.env <- "marginfigure"
-      if (is.null(options$fig.cap)) options$fig.cap <- ""
+      if (is.null(options$fig.cap)) {
+        options$fig.cap <- ""
+      }
+      # Apply margin_fig_pos as the vertical offset for margin figures,
+      # unless the user has set fig.pos explicitly on this chunk (#62)
+      if (
+        !is.null(options$margin_fig_pos) &&
+          (is.null(options$fig.pos) || identical(options$fig.pos, ""))
+      ) {
+        options$fig.pos <- options$margin_fig_pos
+      }
     } else if (isTRUE(options$fig.fullwidth)) {
       options$fig.env <- "figure*"
       if (is.null(options$fig.cap)) options$fig.cap <- ""

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -16,6 +16,7 @@ tufte_handout(
   fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
+  margin_fig_pos = NULL,
   ...
 )
 
@@ -25,6 +26,7 @@ tufte_book(
   fig_crop = "auto",
   dev = "pdf",
   highlight = "default",
+  margin_fig_pos = NULL,
   ...
 )
 
@@ -67,6 +69,16 @@ if these two tools are available.}
   style}. Note that custom theme requires Pandoc 2.0+.
 
   Pass \code{NULL} to prevent syntax highlighting.}
+
+\item{margin_fig_pos}{Default vertical offset for margin figures (a LaTeX
+length such as \code{"0cm"} or \code{"-5pt"}). When set, this value is used as the
+\code{fig.pos} for all chunks with \code{fig.margin = TRUE}, unless the chunk
+specifies its own \code{fig.pos}. This avoids the problem of setting \code{fig.pos}
+globally via \code{knitr::opts_chunk$set()}, which would also affect regular
+figures where \code{fig.pos} is a placement specifier (e.g. \code{"htbp"}), not a
+length. Can also be set per-chunk or via \code{knitr::opts_chunk$set()} as the
+\code{margin_fig_pos} chunk option. Defaults to \code{NULL} (use the Tufte-LaTeX
+class default of \verb{-1.2ex}).}
 
 \item{...}{Other arguments to be passed to \code{\link[rmarkdown:pdf_document]{rmarkdown::pdf_document()}} or
 \code{\link[rmarkdown:html_document]{rmarkdown::html_document()}} (note you cannot use the \code{template}

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -40,7 +40,7 @@ citeproc_variant <- function() {
   } else if (!rmarkdown::pandoc_available("3.1.8")) {
     # Pandoc 2.14.1 fixed  that
     "new-citeproc-post-2.14.1"
-  } else if (!rmarkdown::pandoc_available("3.8")){
+  } else if (!rmarkdown::pandoc_available("3.8")) {
     "new-citeproc-post-3.1.8"
   } else {
     "new-citeproc-post-3.8"

--- a/tests/testthat/test-pdf.R
+++ b/tests/testthat/test-pdf.R
@@ -54,6 +54,122 @@ test_that("tufte_handout renders a basic PDF without error (#127)", {
   expect_true(file.exists(output))
 })
 
+# margin_fig_pos chunk option (#62) ----------------------------------------
+
+local_render_tex <- function(rmd_lines, .env = parent.frame()) {
+  skip_if_not_pandoc()
+  skip_if_not_tinytex()
+  rmd <- local_rmd_file(rmd_lines, .env = .env)
+  output <- withr::local_tempfile(.local_envir = .env, fileext = ".pdf")
+  withCallingHandlers(
+    rmarkdown::render(rmd, output_file = output, quiet = TRUE, clean = FALSE),
+    warning = function(w) {
+      if (
+        grepl(
+          "bibentry|nobibliography|Marginpar",
+          conditionMessage(w),
+          ignore.case = TRUE
+        )
+      ) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
+  tex_file <- xfun::with_ext(output, "tex")
+  if (!file.exists(tex_file)) {
+    skip("keep_tex did not produce a .tex file")
+  }
+  xfun::read_utf8(tex_file)
+}
+
+test_that("margin_fig_pos via YAML sets the marginfigure offset (#62)", {
+  skip_on_cran()
+  tex <- local_render_tex(c(
+    "---",
+    "output:",
+    "  tufte::tufte_handout:",
+    "    keep_tex: true",
+    "    margin_fig_pos: '0.5cm'",
+    "---",
+    "",
+    "```{r fig.margin=TRUE, fig.cap='test', echo=FALSE}",
+    "plot(1:5)",
+    "```",
+    "",
+    "Text after."
+  ))
+  marginfig <- grep("\\\\begin\\{marginfigure\\}", tex, value = TRUE)
+  expect_length(marginfig, 1)
+  expect_match(marginfig, "[0.5cm]", fixed = TRUE)
+})
+
+test_that("margin_fig_pos via opts_chunk$set works (#62)", {
+  skip_on_cran()
+  tex <- local_render_tex(c(
+    "---",
+    "output:",
+    "  tufte::tufte_handout:",
+    "    keep_tex: true",
+    "---",
+    "",
+    "```{r setup, include=FALSE}",
+    "knitr::opts_chunk$set(margin_fig_pos = '0.5cm')",
+    "```",
+    "",
+    "```{r fig.margin=TRUE, fig.cap='test', echo=FALSE}",
+    "plot(1:5)",
+    "```",
+    "",
+    "Text after."
+  ))
+  marginfig <- grep("\\\\begin\\{marginfigure\\}", tex, value = TRUE)
+  expect_length(marginfig, 1)
+  expect_match(marginfig, "[0.5cm]", fixed = TRUE)
+})
+
+test_that("fig.pos overrides margin_fig_pos on a specific chunk (#62)", {
+  skip_on_cran()
+  tex <- local_render_tex(c(
+    "---",
+    "output:",
+    "  tufte::tufte_handout:",
+    "    keep_tex: true",
+    "    margin_fig_pos: '0.5cm'",
+    "---",
+    "",
+    "```{r fig.margin=TRUE, fig.pos='2cm', fig.cap='test', echo=FALSE}",
+    "plot(1:5)",
+    "```",
+    "",
+    "Text after."
+  ))
+  marginfig <- grep("\\\\begin\\{marginfigure\\}", tex, value = TRUE)
+  expect_length(marginfig, 1)
+  # fig.pos takes precedence
+  expect_match(marginfig, "[2cm]", fixed = TRUE)
+})
+
+test_that("margin_fig_pos does not affect regular figures (#62)", {
+  skip_on_cran()
+  tex <- local_render_tex(c(
+    "---",
+    "output:",
+    "  tufte::tufte_handout:",
+    "    keep_tex: true",
+    "    margin_fig_pos: '0.5cm'",
+    "---",
+    "",
+    "```{r fig.cap='regular figure', echo=FALSE}",
+    "plot(1:5)",
+    "```",
+    "",
+    "Text after."
+  ))
+  # Regular figure should NOT have the margin offset
+  figure_lines <- grep("\\\\begin\\{figure\\}", tex, value = TRUE)
+  expect_false(any(grepl("0.5cm", figure_lines, fixed = TRUE)))
+})
+
 test_that("tufte_handout PDF log contains no xcolor usenames warning (#127)", {
   skip_on_cran()
   rmd <- local_rmd_file(


### PR DESCRIPTION
Closes #62.

## Problem

Margin figures in PDF output (`fig.margin = TRUE`) can appear vertically misaligned relative to the adjacent body text, especially after long code blocks. The existing `fig.pos` chunk option can adjust this per-chunk, but **cannot be set globally** because it has different semantics depending on the figure type:

- Regular `\begin{figure}[htbp]` — `fig.pos` is a **placement specifier**
- Margin `\begin{marginfigure}[2cm]` — `fig.pos` is a **vertical offset** (a `\vspace*` length)

Setting `knitr::opts_chunk$set(fig.pos = "2cm")` globally causes `\begin{figure}[2cm]` for regular figures → `! LaTeX Error: Unknown float option '2'`.

## What we tried and ruled out

We investigated patching the upstream `tufte-common.def` to change the `minipage` alignment from center to top (`[t]`) and adjusting the default `-1.2ex` offset. We generated five variant PDFs with different combinations of alignment and offset values. Visual comparison showed the **upstream defaults produce better general alignment** than any `minipage[t]` variant — the center-aligned minipage with `-1.2ex` is a deliberate tuning by the Tufte-LaTeX authors.

## Solution

New `margin_fig_pos` option that controls the vertical offset **only** for margin figures. Three ways to set it, with clear precedence:

| Method | Scope | Example |
|--------|-------|---------|
| YAML parameter | All margin figures | `margin_fig_pos: "0cm"` |
| `opts_chunk$set()` | All subsequent margin figures | `knitr::opts_chunk$set(margin_fig_pos = "0cm")` |
| Per-chunk `fig.pos` | Single chunk (overrides above) | `fig.pos = "1.5cm"` |

Regular figures are never affected.

```yaml
output:
  tufte::tufte_handout:
    margin_fig_pos: "0cm"
```

## Implementation

The change is in the plot hook in `R/handout.R`. When `fig.margin = TRUE` and the user hasn't set `fig.pos` on the specific chunk, `margin_fig_pos` is injected as `fig.pos`. The option is passed through `knitr_options$opts_chunk` when set via YAML, so it follows standard knitr option precedence.

## Tests

- `margin_fig_pos` via YAML sets the `\begin{marginfigure}[value]` offset
- `margin_fig_pos` via `opts_chunk$set()` works the same way
- Per-chunk `fig.pos` overrides `margin_fig_pos`
- `margin_fig_pos` does not affect regular `\begin{figure}` environments
- Manual inspection fixture at `tests/testthat/resources/margin_fig_pos_62.Rmd`
