### PR TITLE
ix `nocite` references dropped in `tufte_html()` with `link-citations: yes`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tufte
 Title: Tufte's Styles for R Markdown Documents
-Version: 0.14.0.9003
+Version: 0.14.0.9004
 Authors@R: c(
     person("Yihui", "Xie", role = "aut", email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Christophe", "Dervieux", role = c("ctb", "cre"), email = "cderv@posit.co", comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   dropped because the figure hook used an exact string match that missed the
   extra `style` attribute added by knitr (#54).
 
+- Fixed `nocite` references being silently dropped in `tufte_html()` when
+  `link-citations: yes`. References without in-text citations are now preserved
+  in the bibliography section at the bottom of the document (#35).
+
 - Removed obsolete `usenames` option from `xcolor` package loading to suppress
   warning on TeX Live 2022+ (#127).
 

--- a/R/html.R
+++ b/R/html.R
@@ -302,10 +302,22 @@ margin_references <- function(x) {
     ref[j] <- sub(dashes, sub("^([^.]+[.])( .+)$", "\\1", ref[j - 1]), ref[j])
   }
   ref <- marginnote_html(paste0('\\1<span class="marginnote">', ref, "</span>"))
+  # Track which references have in-text citations (nocite entries won't match)
+  matched <- logical(n)
   for (j in seq_len(n)) {
-    x <- gsub(ids[j], ref[j], x)
+    if (any(grepl(ids[j], x))) {
+      x <- gsub(ids[j], ref[j], x)
+      matched[j] <- TRUE
+    }
   }
-  x[-(i:(max(k) + 3))] # remove references at the bottom
+  if (all(matched)) {
+    x[-(i:(max(k) + 3))] # remove entire references section
+  } else {
+    # Remove only matched entries; keep nocite references at the bottom
+    remove <- unlist(lapply(k[matched], function(pos) pos:(pos + 2)))
+    if (length(remove) > 0) x <- x[-remove]
+    x
+  }
 }
 
 marginnote_html <- function(text = "", icon = "&#8853;") {

--- a/R/html.R
+++ b/R/html.R
@@ -315,7 +315,9 @@ margin_references <- function(x) {
   } else {
     # Remove only matched entries; keep nocite references at the bottom
     remove <- unlist(lapply(k[matched], function(pos) pos:(pos + 2)))
-    if (length(remove) > 0) x <- x[-remove]
+    if (length(remove) > 0) {
+      x <- x[-remove]
+    }
     x
   }
 }

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -72,6 +72,51 @@ test_that("put references in margin when link-citations: yes using csl", {
   )
 })
 
+test_that("nocite references survive margin_references() (issue #35)", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  rmd <- local_rmd_file(
+    "---",
+    "title: test",
+    "output: tufte::tufte_html",
+    "bibliography: refs.bib",
+    "link-citations: yes",
+    "nocite: |",
+    "  @nocite_only",
+    "---",
+    "",
+    "See @cited_in_text for details."
+  )
+  # Create a minimal .bib next to the Rmd
+  bib <- file.path(dirname(rmd), "refs.bib")
+  xfun::write_utf8(c(
+    "@article{cited_in_text,",
+    "  author = {Smith, John},",
+    "  title = {Cited Article},",
+    "  journal = {J. Examples},",
+    "  year = {2020}",
+    "}",
+    "@article{nocite_only,",
+    "  author = {Doe, Jane},",
+    "  title = {Nocite Article},",
+    "  journal = {J. Nocite},",
+    "  year = {2019}",
+    "}"
+  ), bib)
+  withr::defer(unlink(bib))
+  html <- .render_and_read(rmd)
+  # The nocite-only reference must appear somewhere in the output
+  expect_true(
+    any(grepl("ref-nocite_only", html)),
+    info = "nocite entry should not be dropped when link-citations: yes (issue #35)"
+  )
+  # The in-text reference should also still be present (as margin note)
+  expect_true(
+    any(grepl("Cited Article|ref-cited_in_text", html)),
+    info = "in-text citation should still appear"
+  )
+})
+
 test_that("fig.margin=TRUE works with fig.align set (issue #54)", {
   skip_on_cran()
   skip_if_not_pandoc()

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -89,20 +89,23 @@ test_that("nocite references survive margin_references() (issue #35)", {
   )
   # Create a minimal .bib next to the Rmd
   bib <- file.path(dirname(rmd), "refs.bib")
-  xfun::write_utf8(c(
-    "@article{cited_in_text,",
-    "  author = {Smith, John},",
-    "  title = {Cited Article},",
-    "  journal = {J. Examples},",
-    "  year = {2020}",
-    "}",
-    "@article{nocite_only,",
-    "  author = {Doe, Jane},",
-    "  title = {Nocite Article},",
-    "  journal = {J. Nocite},",
-    "  year = {2019}",
-    "}"
-  ), bib)
+  xfun::write_utf8(
+    c(
+      "@article{cited_in_text,",
+      "  author = {Smith, John},",
+      "  title = {Cited Article},",
+      "  journal = {J. Examples},",
+      "  year = {2020}",
+      "}",
+      "@article{nocite_only,",
+      "  author = {Doe, Jane},",
+      "  title = {Nocite Article},",
+      "  journal = {J. Nocite},",
+      "  year = {2019}",
+      "}"
+    ),
+    bib
+  )
   withr::defer(unlink(bib))
   html <- .render_and_read(rmd)
   # The nocite-only reference must appear somewhere in the output


### PR DESCRIPTION
Closes #35

### Problem

When `link-citations: yes` is set in YAML, `margin_references()` in `R/html.R` moves in-text citation entries into margin notes and then removes the **entire** `<div id="refs">` section. References listed only in `nocite` have no in-text `<a>` link, so they are never placed as margin notes — but they are still removed along with everything else.

### Fix

`margin_references()` now tracks which reference entries were actually matched to an in-text citation link. Only matched entries are removed from the refs div. Unmatched entries (i.e. `nocite`-only references) are preserved in the bibliography section at the bottom of the document.

When all references have in-text links, behaviour is unchanged — the entire refs div is removed as before.

### Testing

- New test confirms the nocite entry appears in rendered output with `link-citations: yes`.
- All 13 existing HTML tests pass with no regressions.
- Verified `tufte_handout()` (LaTeX) is not affected — pandoc/citeproc handles the bibliography natively there.
